### PR TITLE
FPR rule commandline tool

### DIFF
--- a/tools/add-format
+++ b/tools/add-format
@@ -1,0 +1,1 @@
+add-fpr-rule

--- a/tools/add-fpr-rule
+++ b/tools/add-fpr-rule
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+from argparse import ArgumentParser
+import os
+import sys
+
+sys.path.append('/usr/share/archivematica/dashboard')
+os.environ["DJANGO_SETTINGS_MODULE"] = "settings.local"
+
+from django.db import connection
+
+from fpr.models import IDCommand, IDRule, IDTool, Format, FormatGroup, FormatVersion, FPCommand, FPRule, FPTool
+
+FORMAT_FIELDS = (
+    "description",
+    "pronom_id",
+    "version",
+)
+
+IDCOMMAND_FIELDS = (
+    "description",
+    "config",
+    "replaces_id",
+    "script",
+    "script_type",
+    "tool_id",
+)
+
+IDRULE_FIELDS = (
+    "command_output",
+    "command_id",
+    "format_id",
+)
+
+IDTOOL_FIELDS = (
+    "description",
+    "version",
+)
+
+FPCOMMAND_FIELDS = (
+    "description",
+    "tool_id",
+    "command_usage",
+    "command",
+    "script_type",
+    "output_location",
+    "output_format_id",
+    "verification_command_id",
+    "event_detail_command_id",
+    "replaces_id",
+)
+
+
+FPRULE_FIELDS = (
+    "purpose",
+    "command_id",
+    "format_id",
+)
+
+FPTOOL_FIELDS = (
+    "description",
+    "version",
+)
+
+
+NAME_MAP = {
+    "idcommand": (IDCommand, IDCOMMAND_FIELDS),
+    "idrule": (IDRule, IDRULE_FIELDS),
+    "idtool": (IDTool, IDTOOL_FIELDS),
+    "fpcommand": (FPCommand, FPCOMMAND_FIELDS),
+    "fprule": (FPRule, FPRULE_FIELDS),
+    "fptool": (FPTool, FPTOOL_FIELDS),
+}
+
+
+def save_object(obj):
+    obj.save()
+    return connection.queries[-1]['sql']
+
+
+def ask_for_field(field):
+    print(field + ":", file=sys.stderr)
+    s = sys.stdin.readline()
+    if s.endswith("\n"):
+        s = s[0:-1]
+    return s
+
+
+def create_format():
+    obj = FormatVersion()
+
+    format_description = ask_for_field("format")
+    try:
+        format = Format.objects.get(description=format_description)
+    except Format.DoesNotExist:
+        format = Format(description=format_description)
+        sql = save_object(format)
+        print(sql + ";")
+
+    if not format.group:
+        group_description = ask_for_field("format_group")
+        try:
+            group = FormatGroup.objects.get(description=group_description)
+        except FormatGroup.DoesNotExist:
+            group = FormatGroup(description=group_description)
+            sql = save_object(group)
+            print(sql + ";")
+        format.group = group
+
+    for field in FORMAT_FIELDS:
+        val = ask_for_field(field)
+        if val:
+            setattr(obj, field, val)
+
+    sql = save_object(obj)
+    print(sql + ";")
+
+
+def create_rule(kind, command_file=None):
+    klass, fields = NAME_MAP[kind]
+    obj = klass()
+    for field in fields:
+        if command_file and field in ("command", "script"):
+            with open(command_file) as command:
+                val = command.read()
+        else:
+            val = ask_for_field(field)
+
+        # Empty values should be NULL, not empty strings
+        if val:
+            setattr(obj, field, val)
+
+    if hasattr(obj, "replaces") and obj.replaces:
+        obj.replaces.enabled = False
+        sql = save_object(obj.replaces)
+        print(sql + ";")
+
+    sql = save_object(obj)
+    print(sql + ";")
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument("kind", help="Type of FPR rule to create")
+    parser.add_argument("command", nargs="?", default=None,
+                        help="Path to command source code (optional)")
+    opts = parser.parse_args()
+
+    try:
+        if os.path.basename(sys.argv[0]) == "add-format":
+            create_format()
+        else:
+            create_rule(opts.kind, command_file=opts.command)
+    except KeyboardInterrupt:
+        sys.exit("\nAborting")


### PR DESCRIPTION
This pull request adds a new commandline tool which generates FPR rules. It immediately applies the change to the local database, and also emits SQL to stdout that can be captured to reapply the change at a later point in time. That new SQL can be added to `fpr_dev*.sql` files, or applied to the FPR server.

Moved over from artefactual/archivematica#46.