### PR TITLE
Add reindex-aip-data script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ TOOLS PROVIDED
 * create-many-transfers: Stress test an Archivematica instance by starting many transfers at once.
 * extract-mets-files-from-aips: Extract METS files from all AIPs in a given path.
 * rebuild-elasticsearch tools: Various tools to rebuild specific Elasticsearch indices.
+* reindex-aip-data: Delete and recreate the AIP index, reindexing all existing records.
+  This can be used to migrate data when an incompatible schema change occurs.
 * stress-test-aip-indexing: Stress test Elasticsearch AIP indexing by repeatedly indexing test data.
 * sword-diagnose: Attempt to detect any issues in AtoM/SWORD configuration when setting up DIP upload to an AtoM instance.
 

--- a/tools/reindex-aip-data
+++ b/tools/reindex-aip-data
@@ -1,0 +1,35 @@
+#!/usr/bin/python2
+
+from __future__ import print_function
+import sys
+
+from elasticsearch import Elasticsearch, NotFoundError
+import elasticsearch.helpers
+
+sys.path.append('/usr/lib/archivematica/archivematicaCommon')
+import elasticSearchFunctions
+
+conn = Elasticsearch(hosts=elasticSearchFunctions.getElasticsearchServerHostAndPort())
+
+try:
+    mapping = conn.indices.get_mapping('aips')
+except NotFoundError:
+    print("No aips mapping exists - exiting", file=sys.stderr)
+    sys.exit(1)
+
+aip_records = [r['_source'] for r
+               in elasticsearch.helpers.scan(conn, index='aips', doc_type='aip', scroll='15m')]
+aipfile_records = [r['_source'] for r
+                   in elasticsearch.helpers.scan(conn, index='aips', doc_type='aipfile', scroll='15m')]
+
+conn.indices.delete_mapping(index='aips', doc_type='aip')
+conn.indices.delete_mapping(index='aips', doc_type='aipfile')
+elasticSearchFunctions.connect_and_create_index('aips')
+
+print('Indexing {} aips/aip records'.format(len(aip_records)))
+for r in aip_records:
+    conn.index(body=r, index='aips', doc_type='aip')
+
+print('Indexing {} aips/aipfile records'.format(len(aipfile_records)))
+for r in aipfile_records:
+    conn.index(body=r, index='aips', doc_type='aipfile')


### PR DESCRIPTION
This script destroys and rebuilds the `aips` index using the source documents. This is useful in cases where incompatible index type changes are being made; for example, if a type is being converted from a date to a string (see #8812).