### PR TITLE
graph-links: cleanups, comments, tooltips, png...

### DIFF
--- a/tools/graph-links
+++ b/tools/graph-links
@@ -1,8 +1,9 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
 # This file is part of Archivematica.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2015 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -17,19 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
-# @package Archivematica
-# @subpackage MCPServer
-# @author Joseph Perry <joseph@artefactual.com>
-
 import datetime
-import pygraphviz as pgv
 import sys
+import logging
+import argparse
+
+import pygraphviz as pgv
+
+# Quickest way to access to the MCP database but it assumes that you are
+# running this script in the machine where Archivematica was installed.
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")
 import databaseInterface
-
 databaseInterface.printSQL = False
 
-G = pgv.AGraph(strict=True, directed=True)
+
 linkUUIDtoNodeName = {}
 
 excludedNodes = {
@@ -38,8 +40,72 @@ excludedNodes = {
     '333532b9-b7c2-4478-9415-28a3056d58df': "reject transfer option.",
     '19c94543-14cb-4158-986b-1d2b55723cd8': "reject sip option."}
 
+# For each MicroServiceChainLink in the MCP Server, the TaskType determines
+# what code will be executed for that task.
+# See: https://wiki.archivematica.org/MCP/TaskTypes
+TASK_TYPES = {
 
-def addArrow(sourceUUID, destUUID, color="black", label=None):
+    #
+    # General
+    #
+
+    # description="one instance"
+    'one_instance': '36b2e239-4a57-4aa5-8ebc-7a29139baca6',
+
+    # description="for each file"
+    # 'for_each_file': 'a6b1c323-7d36-428e-846a-e7e819423577',
+
+    #
+    # User choice
+    #
+
+    # description="get user choice to proceed with"
+    # '?': '61fb3874-8ef6-49d3-8a2d-3cb66e86a30c',
+
+    # description="get replacement dic from user choice"
+    # '?': '9c84b047-9a6d-463f-9836-eafa49743b84',
+
+    # description="Get microservice generated list in stdOut"
+    # '?': 'a19bfd9f-9989-4648-9351-013a10b382ed',
+
+    # description="Get user choice from microservice generated list"
+    # '?': '01b748fe-2e9d-44e4-ae5d-113f74c9a0ba',
+
+    #
+    # Unit variables
+    #
+
+    # description="linkTaskManagerSetUnitVariable"
+    'unit_var': '6f0b612c-867f-4dfd-8e43-5b35b7f882d7',
+    # description="linkTaskManagerUnitVariableLinkPull"
+    'unit_var_pull': 'c42184a3-1a7f-4c4d-b380-15d8d97fdd11',
+
+    #
+    # Deprecated
+    #
+
+    # description="goto magic link"
+    # '?': '6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9',
+
+    # description="assign magic link"
+    'assign_magic_link': '3590f73d-5eb0-44a0-91a6-5b2db6655889',
+
+}
+
+logging.basicConfig(format='%(message)s', stream=sys.stdout)
+logger = logging.getLogger()
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--format', choices=['png', 'svg'], default='svg')
+    parser.add_argument('-v', '--verbose', action='count')
+    args = parser.parse_args()
+
+    return args
+
+
+def add_edge(G, sourceUUID, destUUID, color="black", label=None):
     if sourceUUID in excludedNodes or destUUID in excludedNodes:
         return
     if sourceUUID is None or destUUID is None:
@@ -50,24 +116,49 @@ def addArrow(sourceUUID, destUUID, color="black", label=None):
         G.add_edge(linkUUIDtoNodeName[sourceUUID], linkUUIDtoNodeName[destUUID], color=color)
 
 
-def loadAllLinks():
-    sql = """SELECT MicroServiceChainLinks.pk, MicroServiceChainLinks.defaultNextChainLink, TasksConfigs.description, TaskTypes.description, TasksConfigs.taskTypePKReference, microserviceGroup
+def load_chain_links(G):
+    """
+    Map all the existing job chain links to nodes in the graph.
+    Default links are represented with black arrows.
+    """
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            MicroServiceChainLinks.defaultNextChainLink,
+            TasksConfigs.description,
+            TaskTypes.description,
+            TasksConfigs.taskTypePKReference,
+            MicroServiceChainLinks.microserviceGroup
         FROM MicroServiceChainLinks
         JOIN TasksConfigs ON currentTask = TasksConfigs.pk
-        JOIN TaskTypes ON taskType = TaskTypes.pk
-        WHERE TasksConfigs.taskType != '5e70152a-9c5b-4c17-b823-c9298c546eeb';"""
+        JOIN TaskTypes ON taskType = TaskTypes.pk;
+    """
     links = databaseInterface.queryAllSQL(sql)
     for link in links:
         pk, defaultNextChainLink, description, taskType, pkRef, group = link
         if pk in excludedNodes:
             continue
-        sql = """SELECT execute FROM StandardTasksConfigs WHERE pk='%s';""" % pkRef
-        script_name = databaseInterface.queryAllSQL(sql)
+        sql = """
+            SELECT
+                execute,
+                arguments
+            FROM StandardTasksConfigs
+            WHERE pk=%s;
+        """
+        script_name = databaseInterface.queryAllSQL(sql, (pkRef,))
+        arguments = None
         if script_name:
-            script_name = script_name[0][0]
+            script_name, arguments = script_name[0]
         elif not script_name:
-            sql = """SELECT variable, variableValue, microServiceChainLink FROM TasksConfigsSetUnitVariable WHERE pk='%s';""" % pkRef
-            returned = databaseInterface.queryAllSQL(sql)
+            sql = """
+                SELECT
+                    variable,
+                    variableValue,
+                    microServiceChainLink
+                FROM TasksConfigsSetUnitVariable
+                WHERE pk=%s;
+            """
+            returned = databaseInterface.queryAllSQL(sql, (pkRef,))
             if returned:
                 script_name = '%s, %s' % (returned[0][0], returned[0][1] or returned[0][2])
         # Node info:
@@ -77,140 +168,278 @@ def loadAllLinks():
         nodeName = r"{%s} %s\n(%s) %s\n[%s] %s" % (pk, description, taskType, pkRef, script_name or '', group)
         # Color if start of chain
         border_color = 'black'
-        sql = """SELECT * FROM MicroServiceChains WHERE startingLink='%s';""" % pk
-        if databaseInterface.queryAllSQL(sql):
+        sql = """
+            SELECT *
+            FROM MicroServiceChains
+            WHERE startingLink=%s;
+        """
+        if databaseInterface.queryAllSQL(sql, (pk,)):
             border_color = 'darkgoldenrod'
-        G.add_node(nodeName, URL="MicroServiceChainLinks/%s" % pk, label=nodeName, id=nodeName, color=border_color)
+        tooltip = 'Arguments: {}'.format(arguments) if arguments is not None else 'No arguments'
+        G.add_node(nodeName, label=nodeName, id=nodeName, color=border_color, tooltip=tooltip)
         linkUUIDtoNodeName[pk] = nodeName
     for link in links:
         pk = link[0]
         defaultNextChainLink = link[1]
         if defaultNextChainLink is not None:
-            addArrow(pk, defaultNextChainLink)
+            add_edge(G, pk, defaultNextChainLink, label='defaultNextChainLink')
     return
 
 
-def bridgeExitCodes():
-    global allLinks
-    sql = """SELECT microServiceChainLink, nextMicroServiceChainLink, exitCode FROM MicroServiceChainLinksExitCodes;"""
-    links = databaseInterface.queryAllSQL(sql)
-    for link in links:
-        microServiceChainLink, nextMicroServiceChainLink, exit_code = link
+def bridgeExitCodes(G):
+    """
+    Connect tasks based on the exit code. The edges are red if the exit code is
+    greater than zero and green otherwise. The exit code is included in the
+    label of the edge.
+    """
+    sql = """
+        SELECT
+            microServiceChainLink,
+            nextMicroServiceChainLink,
+            exitCode
+        FROM MicroServiceChainLinksExitCodes;
+    """
+    logger.info('Processing exit codes...')
+    rows = databaseInterface.queryAllSQL(sql)
+    for row in rows:
+        microServiceChainLink, nextMicroServiceChainLink, exit_code = row
         if nextMicroServiceChainLink:
-            if exit_code:
-                addArrow(microServiceChainLink, nextMicroServiceChainLink, label=exit_code)
-            else:
-                addArrow(microServiceChainLink, nextMicroServiceChainLink)
-    return
+            color = 'green' if not exit_code else 'red'
+            add_edge(G, microServiceChainLink, nextMicroServiceChainLink, label='EXITCODE={}'.format(exit_code), color=color)
 
 
-def bridgeUserSelections():
-    sql = "SELECT MicroServiceChainChoice.choiceAvailableAtLink, MicroServiceChains.startingLink, MicroServiceChains.description FROM MicroServiceChainChoice JOIN MicroServiceChains ON MicroServiceChainChoice.chainAvailable = MicroServiceChains.pk;"
+def bridgeUserSelections(G):
+    """
+    Connect tasks that prompt the user with its corresponding choices. The
+    arrows are green and labeled with the choice description.
+    """
+    logger.info('Processing user choices...')
+    sql = """
+        SELECT
+            MicroServiceChainChoice.choiceAvailableAtLink,
+            MicroServiceChains.startingLink,
+            MicroServiceChains.description
+        FROM MicroServiceChainChoice
+        JOIN MicroServiceChains ON (MicroServiceChainChoice.chainAvailable = MicroServiceChains.pk);
+    """
     rows = databaseInterface.queryAllSQL(sql)
     for row in rows:
         choiceAvailableAtLink, startingLink, description = row
         if choiceAvailableAtLink and startingLink:
-            addArrow(choiceAvailableAtLink, startingLink, color='green', label=description)
+            add_edge(G, choiceAvailableAtLink, startingLink, color='blue', label=description)
 
 
-def bridgeWatchedDirectories():
-    global allLinks
-    sql = "SELECT watchedDirectoryPath, startingLink FROM WatchedDirectories Join MicroServiceChains ON WatchedDirectories.chain = MicroServiceChains.pk;"
+def bridgeWatchedDirectories(G):
+    """
+    Connect tasks that represent the end of a chain that moves a package to the
+    watched directory of the new chain. The arrors are yellow.
+
+    For example:
+
+        > {61a8de9c-7b25-4f0f-b218-ad4dde261eed} Generate DIP
+        > (one instance) ed8c70b7-1456-461c-981b-6b9c84896263
+        > [move_v0.0] Prepare DIP
+
+            [↓] (yellow)
+
+        > {92879a29-45bf-4f0b-ac43-e64474f0f2f9} Upload DIP
+        > (get user choice to proceed with) None
+        > [] Upload DIP
+
+    Not all the chains are triggered by other tasks, e.g. the following task
+    has no successor.
+
+        > {9520386f-bb6d-4fb9-a6b6-5845ef39375f} Approve AIP reingest
+        > (get user choice to proceed with) None
+        > [] Reingest AIP
+
+    """
+    logger.info('Processing watched directories...')
+    sql = """
+        SELECT
+            watchedDirectoryPath,
+            startingLink
+        FROM WatchedDirectories
+        JOIN MicroServiceChains ON (WatchedDirectories.chain = MicroServiceChains.pk);
+    """
     rows = databaseInterface.queryAllSQL(sql)
     for row in rows:
-        countOfSources = 0
         watchedDirectoryPath, startingLink = row
-        sql = "SELECT MicroServiceChainLinks.pk FROM StandardTasksConfigs JOIN TasksConfigs ON TasksConfigs.taskTypePKReference = StandardTasksConfigs.pk JOIN MicroServiceChainLinks ON MicroServiceChainLinks.currentTask = TasksConfigs.pk WHERE execute LIKE 'move%%' AND taskType = '36b2e239-4a57-4aa5-8ebc-7a29139baca6' AND arguments like '%%%s%%';" % (watchedDirectoryPath.replace('%', '\%'))
-        rows2 = databaseInterface.queryAllSQL(sql)
+        logger.debug("\nWatched directory [%s] [startingLink=%s]",
+            watchedDirectoryPath.replace('%watchDirectoryPath%', ''),
+            startingLink)
+        count = 0
+
+        sql = """
+            SELECT
+                MicroServiceChainLinks.pk,
+                execute,
+                arguments
+            FROM StandardTasksConfigs
+            JOIN TasksConfigs ON (TasksConfigs.taskTypePKReference = StandardTasksConfigs.pk)
+            JOIN MicroServiceChainLinks ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+            WHERE
+                execute LIKE 'move%%'
+                AND taskType = %s
+                AND (arguments LIKE %s OR arguments LIKE %s);
+        """
+        rows2 = databaseInterface.queryAllSQL(sql, (
+            TASK_TYPES['one_instance'],
+            '%{}%'.format(watchedDirectoryPath.replace('%', '\%')),
+            '%{}%'.format(watchedDirectoryPath.replace('%watchDirectoryPath%', '%sharedPath%watchedDirectories/', 1).replace('%', '\%')),
+        ))
         for row2 in rows2:
-            microServiceChainLink = row2[0]
-            addArrow(microServiceChainLink, startingLink, color="yellow", label=watchedDirectoryPath)
-            countOfSources += 1
-        sql = "SELECT MicroServiceChainLinks.pk FROM StandardTasksConfigs JOIN TasksConfigs ON TasksConfigs.taskTypePKReference = StandardTasksConfigs.pk JOIN MicroServiceChainLinks ON MicroServiceChainLinks.currentTask = TasksConfigs.pk WHERE execute LIKE 'move%%' AND taskType = '36b2e239-4a57-4aa5-8ebc-7a29139baca6' AND arguments like '%%%s%%';" % (watchedDirectoryPath.replace('%watchDirectoryPath%', '%sharedPath%watchedDirectories/', 1).replace('%', '\%'))
-        rows2 = databaseInterface.queryAllSQL(sql)
-        for row2 in rows2:
-            microServiceChainLink = row2[0]
-            addArrow(microServiceChainLink, startingLink, color="yellow", label=watchedDirectoryPath)
-            countOfSources += 1
+            microServiceChainLink, execute, arguments = row2
+            add_edge(G, microServiceChainLink, startingLink, color='yellow', label=watchedDirectoryPath)
+            logger.debug('  MATCHED SOURCE:\n   -> %s \n   -> %s\n   -> %s', microServiceChainLink, execute, arguments)
+            count += 1
 
-        if countOfSources == 0:
-            print "no sources for watched directory: ", watchedDirectoryPath
-
-    return
+        if count == 0:
+            logger.info("No sources for watched directory: %s", watchedDirectoryPath)
 
 
-def bridgeMagicChainLinks():
+def bridgeMagicChainLinks(G):
     # find the assignments
-    sql = "SELECT MicroServiceChainLinks.pk, TasksConfigsAssignMagicLink.execute FROM MicroServiceChainLinks JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk JOIN TasksConfigsAssignMagicLink ON TasksConfigsAssignMagicLink.pk = TasksConfigs.taskTypePKReference WHERE TasksConfigs.taskType = '3590f73d-5eb0-44a0-91a6-5b2db6655889';"
-    rows = databaseInterface.queryAllSQL(sql)
-
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            TasksConfigsAssignMagicLink.execute
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        JOIN TasksConfigsAssignMagicLink ON (TasksConfigsAssignMagicLink.pk = TasksConfigs.taskTypePKReference)
+        WHERE TasksConfigs.taskType = %s;
+    """
+    rows = databaseInterface.queryAllSQL(sql, (TASK_TYPES['assign_magic_link'],))
     for row in rows:
         microServiceChainLink, magicLink = row
         node = G.get_node(linkUUIDtoNodeName[microServiceChainLink])
-
-        visitedNodes = {node: None}  # prevents looping
-        count = bridgeMagicChainLinksRecursiveAssist(node, magicLink, visitedNodes)
+        # Keep a list of visited nodes to avoid infinite recursion
+        visitedNodes = {node: None}
+        count = bridgeMagicChainLinksRecursiveAssist(G, node, magicLink, visitedNodes)
         if count == 0:
-            print "no loads of set link: ", node
-    return
+            logger.info("No loads of set link: %s", node)
 
 
-def bridgeMagicChainLinksRecursiveAssist(node, magicLink, visitedNodes):
+def bridgeMagicChainLinksRecursiveAssist(G, node, magicLink, visitedNodes):
     ret = 0
     link = node[1:node.find('}')]
-    sql = "SELECT MicroServiceChainLinks.pk FROM MicroServiceChainLinks JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk WHERE TasksConfigs.taskType = '6fe259c2-459d-4d4b-81a4-1b9daf7ee2e9' AND MicroServiceChainLinks.pk = '%s';" % (link)
+    sql = """
+        SELECT MicroServiceChainLinks.pk
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        WHERE
+            TasksConfigs.taskType = %s
+            AND MicroServiceChainLinks.pk = %s;
+    """
+    rows = databaseInterface.queryAllSQL(sql, (
+        TASK_TYPES['assign_magic_link'],
+        link,
+    ))
     # if it's loading it, set the load and return
-    rows = databaseInterface.queryAllSQL(sql)
     if len(rows):
-        addArrow(link, magicLink, color="brown")
+        add_edge(G, link, magicLink, color="brown")
         return 1
     else:
         for neigh in G.neighbors_iter(node):
             if neigh in visitedNodes:
                 continue
             visitedNodes[neigh] = None
-            ret += bridgeMagicChainLinksRecursiveAssist(neigh, magicLink, visitedNodes)
+            ret += bridgeMagicChainLinksRecursiveAssist(G, neigh, magicLink, visitedNodes)
     return ret
 
 
-def bridgeLoadVariable():
-    sql = "SELECT MicroServiceChainLinks.pk, TasksConfigsUnitVariableLinkPull.variable, TasksConfigsUnitVariableLinkPull.defaultMicroServiceChainLink FROM MicroServiceChainLinks JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk JOIN TasksConfigsUnitVariableLinkPull ON TasksConfigsUnitVariableLinkPull.pk = TasksConfigs.taskTypePKReference WHERE TasksConfigs.taskType = 'c42184a3-1a7f-4c4d-b380-15d8d97fdd11';"
-    rows = databaseInterface.queryAllSQL(sql)
+def bridgeLoadVariable(G):
+    sql = """
+        SELECT
+            MicroServiceChainLinks.pk,
+            TasksConfigsUnitVariableLinkPull.variable,
+            TasksConfigsUnitVariableLinkPull.defaultMicroServiceChainLink
+        FROM MicroServiceChainLinks
+        JOIN TasksConfigs ON (MicroServiceChainLinks.currentTask = TasksConfigs.pk)
+        JOIN TasksConfigsUnitVariableLinkPull ON (TasksConfigsUnitVariableLinkPull.pk = TasksConfigs.taskTypePKReference)
+        WHERE TasksConfigs.taskType = %s;
+    """
+    rows = databaseInterface.queryAllSQL(sql, (TASK_TYPES['unit_var_pull'],))
     for row in rows:
         count = 0
         microServiceChainLink, variable, defaultMicroServiceChainLink = row
-        sql = "SELECT MicroServiceChainLinks.pk, TasksConfigsSetUnitVariable.variable, TasksConfigsSetUnitVariable.microServiceChainLink  FROM MicroServiceChainLinks JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk JOIN TasksConfigsSetUnitVariable ON TasksConfigsSetUnitVariable.pk = TasksConfigs.taskTypePKReference WHERE TasksConfigs.taskType = '6f0b612c-867f-4dfd-8e43-5b35b7f882d7' AND TasksConfigsSetUnitVariable.variable = '%s';" % (variable)
-        rows2 = databaseInterface.queryAllSQL(sql)
+        sql = """
+            SELECT
+                MicroServiceChainLinks.pk,
+                TasksConfigsSetUnitVariable.variable,
+                TasksConfigsSetUnitVariable.microServiceChainLink
+            FROM MicroServiceChainLinks
+            JOIN TasksConfigs ON MicroServiceChainLinks.currentTask = TasksConfigs.pk
+            JOIN TasksConfigsSetUnitVariable ON TasksConfigsSetUnitVariable.pk = TasksConfigs.taskTypePKReference
+            WHERE
+                TasksConfigs.taskType = %s
+                AND TasksConfigsSetUnitVariable.variable = %s;
+        """
+        rows2 = databaseInterface.queryAllSQL(sql, (
+            TASK_TYPES['unit_var'],
+            variable,
+        ))
         for row2 in rows2:
             microServiceChainLink2, variable, microServiceChainLinkDest = row2
-            addArrow(microServiceChainLink, microServiceChainLinkDest, color="orangered", label=variable)
+            add_edge(G, microServiceChainLink, microServiceChainLinkDest, color="orangered", label=variable)
             count += 1
         if defaultMicroServiceChainLink:
-            addArrow(microServiceChainLink, defaultMicroServiceChainLink, color="orangered", label='default MSCL')
+            add_edge(G, microServiceChainLink, defaultMicroServiceChainLink, color="orangered", label='default MSCL')
         if count == 0:
-            print "no bridge variable set for: ", linkUUIDtoNodeName[microServiceChainLink]
-    return
+            logger.info("No bridge variable set for %s", linkUUIDtoNodeName[microServiceChainLink])
 
 
-def draw():
-    print "Creating"
+def main():
+    args = parse_arguments()
+
+    if args.verbose == 1:
+        logger.setLevel(logging.INFO)
+    elif args.verbose > 1:
+        logger.setLevel(logging.DEBUG)
+
+    G = pgv.AGraph(strict=True, directed=True)
+
+    # Nodes
+    load_chain_links(G)
+
+    # Edges
+    bridgeExitCodes(G)           # Green or red edges
+    bridgeUserSelections(G)      # Blue edges
+    bridgeWatchedDirectories(G)  # Yellow edges
+    bridgeLoadVariable(G)        # Orange edges
+    bridgeMagicChainLinks(G)     # Brown edges
+
+    # HACK? Represent the connection of the transfer and the ingest chains.
+    #
+    #     > {3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5} Move to SIP creation directory for completed transfers
+    #     > (one instance) ac562701-7672-4e1d-a318-b986b7c9007c
+    #     > [moveTransfer_v0.0] Create SIP from Transfer
+    #
+    #         [↓] (black)
+    #
+    #     > {db6d3830-9eb4-4996-8f3a-18f4f998e07f} Set file permissions
+    #     > (one instance) 6157fe87-26ff-49da-9899-d9036b21c4b0
+    #     > [setDirectoryPermissionsForAppraisal_v0.0] Verify SIP compliance
+    #
+    add_edge(G, '3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5', 'db6d3830-9eb4-4996-8f3a-18f4f998e07f', color='pink', label='Transfer -> Ingest (manual)')
+
     G.layout(prog='dot')
-    args = "-Goverlap=prism -v "
-    # G.draw('chainlinks-{}.png'.format(datetime.date.today()), args=args)  # firefox
-    G.draw('chainlinks-{}.svg'.format(datetime.date.today()), args=args)  # inkscape
 
+    date = datetime.date.today()
+    filename = 'chainlinks-{}.{}'.format(date, args.format)
+    draw_args = "-Goverlap=prism "
+    if args.verbose > 2:
+        draw_args += "-v "
 
-def bridgeSpecial():
-    # sip to transfer
-    addArrow('3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5', 'db6d3830-9eb4-4996-8f3a-18f4f998e07f')
+    ret = 1    
+    try:
+        G.draw(filename, args=draw_args)
+        ret = 0
+    except:
+        logger.exception('G.draw() failed! See exception details below...\n\n')
+
+    return ret
 
 
 if __name__ == '__main__':
-    loadAllLinks()
-    bridgeExitCodes()
-    bridgeUserSelections()
-    bridgeWatchedDirectories()
-    bridgeLoadVariable()
-    bridgeMagicChainLinks()
-    bridgeSpecial()
-    draw()
+    sys.exit(main())


### PR DESCRIPTION
- Updated shebang
- Formatted SQL queries for better readability and proper parameter escaping.
- Node tooltips with command arguments.
- Some code comments, please forgive if they are not very accurate.
- The `pgv.AGraph` is not a global anymore.
- Added `-f` flag, e.g. `png`, `svg` (default)...
- Added `-v` flag (accumulative):
  - `-v`: logger level is set to `INFO`
  - `-vv`: logger level is set to `DEBUG`
  - `-vvv`: logger level is set to `DEBUG` and graphviz in verbose mode