### PR TITLE
reindex-index-data: use the bulk API for indexing

### DIFF
--- a/tools/reindex-index-data
+++ b/tools/reindex-index-data
@@ -11,6 +11,20 @@ sys.path.append('/usr/lib/archivematica/archivematicaCommon')
 import elasticSearchFunctions
 
 
+def index_iterator(records, index, doc_type, action='index'):
+    """
+    Creates an iterator which yields dicts suitable for use with Elasticsearch's bulk operation API.
+    Used by `reindex` to transform a list of _source records into actions ready for indexing.
+    """
+    for record in records:
+        yield {
+            '_op_type': action,
+            '_index': index,
+            '_type': doc_type,
+            '_source': record,
+        }
+
+
 def reindex(index, doc_types):
     """
     Delete and recreate index/doc_types in Elasticsearch.
@@ -38,8 +52,7 @@ def reindex(index, doc_types):
     # Reindex with the same data
     for doc_type, records in doctype_records.items():
         print('Indexing', len(records), index + '/' + doc_type, 'records.')
-        for r in records:
-            conn.index(body=r, index=index, doc_type=doc_type)
+        elasticsearch.helpers.bulk(conn, index_iterator(records, index, doc_type))
         print('Done indexing', len(records), index + '/' + doc_type, 'records.')
 
 if __name__ == '__main__':

--- a/tools/reindex-index-data
+++ b/tools/reindex-index-data
@@ -4,7 +4,7 @@ from __future__ import print_function
 import argparse
 import sys
 
-from elasticsearch import Elasticsearch, NotFoundError
+from elasticsearch import Elasticsearch, ElasticsearchException, NotFoundError
 import elasticsearch.helpers
 
 sys.path.append('/usr/lib/archivematica/archivematicaCommon')
@@ -52,7 +52,11 @@ def reindex(index, doc_types):
     # Reindex with the same data
     for doc_type, records in doctype_records.items():
         print('Indexing', len(records), index + '/' + doc_type, 'records.')
-        elasticsearch.helpers.bulk(conn, index_iterator(records, index, doc_type))
+        try:
+            elasticsearch.helpers.bulk(conn, index_iterator(records, index, doc_type))
+        except ElasticsearchException as e:
+            print('Indexing failed for index {}, type {}, for reason: {}'.format(index, doc_type, e), file=sys.stderr)
+            continue
         print('Done indexing', len(records), index + '/' + doc_type, 'records.')
 
 if __name__ == '__main__':


### PR DESCRIPTION
When indexing very large number of records, Elasticsearch may have difficulty handling tens of thousands of individual requests in a short time period. The bulk API provides a method to do all of this in a more robust way.