### PR TITLE
reindex-index-data: add --chunk-size arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ reindex-index-data will delete and re-index an ElasticSearch index, creating it 
 This is useful if the mapping has changed in an incompatible way but the existing data should be preserved.
 Depending on the size of the index, a large amount of memory may be consumed.
 
-There is one parameter which specifies which index to recreate: `transfers` or `aips`.
+There is one positional argument which specifies which index to recreate: `transfers` or `aips`. Additionally, the optional parameter `--chunk-size` allows the user to decide how many documents are sent to Elasticsearch in one chunk. This can help to circumvent timeout issues when the documents are very big.

--- a/tools/add-fpr-rule
+++ b/tools/add-fpr-rule
@@ -1,4 +1,22 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 from argparse import ArgumentParser

--- a/tools/create-many-transfers
+++ b/tools/create-many-transfers
@@ -1,4 +1,23 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
 import tempfile
 import os

--- a/tools/extract-mets-files-from-aips
+++ b/tools/extract-mets-files-from-aips
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, subprocess, tempfile, shutil, ConfigParser
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")

--- a/tools/gearman-info
+++ b/tools/gearman-info
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
-# This file is part of Archivematica.
+# This file is part of the Archivematica development tools.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.    If not, see <http://www.gnu.org/licenses/>.
-
-# @package Archivematica
-# @subpackage MCPrpcCLI
-# @author Joseph Perry <joseph@artefactual.com>
 
 import gearman
 admin = gearman.admin_client.GearmanAdminClient(host_list=["127.0.0.1"])

--- a/tools/graph-links
+++ b/tools/graph-links
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
-# This file is part of Archivematica.
+# This file is part of the Archivematica development tools.
 #
 # Copyright 2010-2015 Artefactual Systems Inc. <http://artefactual.com>
 #

--- a/tools/linktool
+++ b/tools/linktool
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from optparse import OptionParser
 import sys

--- a/tools/mcp-rpc-cli
+++ b/tools/mcp-rpc-cli
@@ -1,8 +1,9 @@
 #!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
-# This file is part of Archivematica.
+# This file is part of the Archivematica development tools.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.    If not, see <http://www.gnu.org/licenses/>.
-
-# @package Archivematica
-# @subpackage MCPrpcCLI
-# @author Joseph Perry <joseph@artefactual.com>
 
 import gearman
 import cPickle

--- a/tools/rebuild-elasticsearch-aip-index-from-files
+++ b/tools/rebuild-elasticsearch-aip-index-from-files
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import ConfigParser
 import shutil

--- a/tools/rebuild-elasticsearch-aip-index-from-mets-files-only
+++ b/tools/rebuild-elasticsearch-aip-index-from-mets-files-only
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, subprocess, tempfile, shutil, ConfigParser
 import xml.etree.ElementTree as ElementTree

--- a/tools/rebuild-elasticsearch-transfer-index-from-files
+++ b/tools/rebuild-elasticsearch-transfer-index-from-files
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, subprocess, tempfile, shutil, ConfigParser, subprocess
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")

--- a/tools/reindex-backlogged-transfers
+++ b/tools/reindex-backlogged-transfers
@@ -1,4 +1,22 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 import sys

--- a/tools/reindex-index-data
+++ b/tools/reindex-index-data
@@ -1,4 +1,22 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
 import argparse

--- a/tools/reindex-index-data
+++ b/tools/reindex-index-data
@@ -43,12 +43,13 @@ def index_iterator(records, index, doc_type, action='index'):
         }
 
 
-def reindex(index, doc_types):
+def reindex(index, doc_types, chunk_size):
     """
     Delete and recreate index/doc_types in Elasticsearch.
 
     :param str index: Index to recreate
     :param list doc_types: List of doc types to recreate
+    :param int chunk_size: Number of docs in one chunk sent to Elasticsearch
     """
     conn = Elasticsearch(hosts=elasticSearchFunctions.getElasticsearchServerHostAndPort())
 
@@ -71,7 +72,7 @@ def reindex(index, doc_types):
     for doc_type, records in doctype_records.items():
         print('Indexing', len(records), index + '/' + doc_type, 'records.')
         try:
-            elasticsearch.helpers.bulk(conn, index_iterator(records, index, doc_type))
+            elasticsearch.helpers.bulk(conn, index_iterator(records, index, doc_type), chunk_size)
         except ElasticsearchException as e:
             print('Indexing failed for index {}, type {}, for reason: {}'.format(index, doc_type, e), file=sys.stderr)
             continue
@@ -80,6 +81,7 @@ def reindex(index, doc_types):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Regenerate index based on the existing data to update the index types.')
     parser.add_argument('index', choices=['transfers', 'aips'], help='Index to re-generate.')
+    parser.add_argument('--chunk-size', type=int, default=50, help='Number of docs in one chunk sent to Elasticsearch.')
     args = parser.parse_args()
 
     index_doctypes = {
@@ -87,4 +89,4 @@ if __name__ == '__main__':
         'aips': ['aip', 'aipfile'],
     }
 
-    sys.exit(reindex(args.index, index_doctypes[args.index]))
+    sys.exit(reindex(args.index, index_doctypes[args.index], args.chunk_size))

--- a/tools/restart-elasticsearch-if-down
+++ b/tools/restart-elasticsearch-if-down
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import sys

--- a/tools/restart-services
+++ b/tools/restart-services
@@ -1,4 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 sudo service gearman-job-server stop
 sudo stop archivematica-mcp-server

--- a/tools/stress-test-aip-indexing
+++ b/tools/stress-test-aip-indexing
@@ -1,4 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# This file is part of the Archivematica development tools.
+#
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
+#
+# Archivematica is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Archivematica is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
 
 import os, sys, time
 sys.path.append("/usr/lib/archivematica/archivematicaCommon")

--- a/tools/sword-diagnose
+++ b/tools/sword-diagnose
@@ -1,8 +1,9 @@
-#!/usr/bin/python -OO
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
-# This file is part of Archivematica.
+# This file is part of the Archivematica development tools.
 #
-# Copyright 2010-2013 Artefactual Systems Inc. <http://artefactual.com>
+# Copyright 2010-2016 Artefactual Systems Inc. <http://artefactual.com>
 #
 # Archivematica is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -16,10 +17,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Archivematica.  If not, see <http://www.gnu.org/licenses/>.
-
-# @package Archivematica
-# @subpackage DevCleanup
-# @author Mike Cantelon <mike@artefactual.com>
 
 import subprocess, urllib
 


### PR DESCRIPTION
New `--chunk-size` argument allows me to control the size of the batches in bulk indexing, which is useful when dealing with read timeouts likely because of the size of the documents that we are indexing. 