### PR TITLE
rebuild-transfer-backlog ensures file exists on disk

### DIFF
--- a/tools/rebuild-transfer-backlog
+++ b/tools/rebuild-transfer-backlog
@@ -77,6 +77,11 @@ def process_transfer(es_client, path, sharedDirectory):
         location = file.find('{http://www.loc.gov/METS/}FLocat')
         file_path = location.attrib['{http://www.w3.org/1999/xlink}href']
 
+        # Deleted archives (e.g., .zip) files will be listed in the transfer
+        # METS.xml but they will not exist on disk.
+        if not os.path.exists(file_path):
+            continue
+
         # Create sanitized version of path
         path_to_object = os.path.dirname(file_path)
         file_basename_sanitized = sanitizeNames.sanitizeName(os.path.basename(file_path))

--- a/tools/rebuild-transfer-backlog
+++ b/tools/rebuild-transfer-backlog
@@ -128,7 +128,15 @@ def main():
 
     # Set transfer backlog directory
     try:
-        transfer_backlog_dir = sys.argv[1]
+        user_tbd = sys.argv[1]
+        # The user will pass in something like
+        # /var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog/
+        # because that's what is displayed in the SS GUI.
+        # However, the transfers in backlog are actually stored in an originals/
+        # subdir, e.g.,
+        # /var/archivematica/sharedDirectory/www/AIPsStore/transferBacklog/originals/
+        # so we add that subdir here.
+        transfer_backlog_dir = os.path.join(user_tbd, 'originals')
         if not os.path.exists(transfer_backlog_dir):
             print("Transfer Backlog location doesn't exist.")
             sys.exit(1)
@@ -136,7 +144,7 @@ def main():
         print('Usage: am rebuild-transfer-backlog <Full path to Transfer Backlog>')
         sys.exit(1)
 
-    print('Rebuilding transfer index from transfer backlog in', transfer_backlog_dir)
+    print('Rebuilding transfer index from transfer backlog in', user_tbd)
 
     # Verify ES is accessible
     try:


### PR DESCRIPTION
Relates to https://github.com/artefactual/archivematica-devtools/pull/37

After the above PR was merged, it was discovered that if rebuild-transfer-backlog was run against a backlogged transfer that contained archived dirs (e.g., .zip files) that were deleted during transfer, then the transfer METS would list them and rebuild-transfer-backlog would assume, contrary to fact, that they existed on disk. This triggered an exception, causing the rebuild to fail. This PR fixes this by skipping files that don't exist on disk.