### PR TITLE
mcp-rpc-cli: send user_id in rpc calls

### DIFF
--- a/tools/mcp-rpc-cli
+++ b/tools/mcp-rpc-cli
@@ -48,6 +48,7 @@ class MCPClient:
         data["jobUUID"] = uuid
         data["chain"] = choice
         data["uid"] = "1"
+        data["user_id"] = "1"
         completed_job_request = gm_client.submit_job("approveJob", cPickle.dumps(data), None)
         #self.check_request_status(completed_job_request)
         return


### PR DESCRIPTION
Hardcoded to "1" for now

Connects to https://github.com/archivematica/Issues/issues/728
Related to https://github.com/archivematica/Issues/issues/529